### PR TITLE
Add placeholder prop to SearchField

### DIFF
--- a/src/components/SearchField.tsx
+++ b/src/components/SearchField.tsx
@@ -15,13 +15,14 @@ import styles from './SearchField.module.css';
 
 interface SearchFieldProps extends AriaSearchFieldProps {
   label?: string;
+  placeholder?: string;
   value?: string;
   delay?: number;
   onSearch?: (value: string) => void;
 }
 
 const SearchField = forwardRef(
-  ({ label, value, delay = 0, onSearch, className, ...props }: SearchFieldProps, ref: Ref<any>) => {
+  ({ label, placeholder, value, delay = 0, onSearch, className, ...props }: SearchFieldProps, ref: Ref<any>) => {
     const [search, setSearch] = useState(value ?? '');
     const searchValue = useDebounce(search, delay);
 
@@ -56,6 +57,7 @@ const SearchField = forwardRef(
                 <Icons.MagnifyingGlass className={classNames(styles.search, inputStyles.icon)} />
                 <Input
                   className={classNames(styles.input, inputStyles.input)}
+                  placeholder={placeholder}
                   onChange={handleChange}
                 />
                 {state.value && (

--- a/src/content/docs/components/search-field.mdx
+++ b/src/content/docs/components/search-field.mdx
@@ -8,6 +8,12 @@ A search field.
   <SearchField autoComplete="off" />
 </Example>
 
+## Placeholder text
+
+<Example>
+  <SearchField placeholder="Enter some text" />
+</Example>
+
 ## With delay
 
 <Example>


### PR DESCRIPTION
This PR adds a `placeholder` prop to the `SearchField` component, allowing developers to specify placeholder text for the input field. This improves usability by providing a hint about the expected input.
