### PR TITLE
Fix onPress Prop Handling in ThemeButton

### DIFF
--- a/src/components/ThemeButton.tsx
+++ b/src/components/ThemeButton.tsx
@@ -1,12 +1,13 @@
 import { useTransition, animated } from '@react-spring/web';
 import classNames from 'classnames';
+import { PressEvent } from 'react-aria-components';
 import { Button, ButtonProps } from './Button';
 import { Icon } from './Icon';
 import { Icons } from './Icons';
 import { useTheme } from './hooks/useTheme';
 import styles from './ThemeButton.module.css';
 
-export function ThemeButton({ className, variant = 'quiet', ...props }: ButtonProps) {
+export function ThemeButton({ className, variant = 'quiet', onPress, ...props }: ButtonProps) {
   const { theme, setTheme } = useTheme();
 
   const transitions = useTransition(theme, {
@@ -22,8 +23,9 @@ export function ThemeButton({ className, variant = 'quiet', ...props }: ButtonPr
     },
   });
 
-  function handleClick() {
+  function handleClick(e: PressEvent) {
     setTheme(theme === 'light' ? 'dark' : 'light');
+    onPress?.(e);
   }
 
   return (


### PR DESCRIPTION
Previously, the `onPress` prop passed to `ThemeButton` was overwritten, preventing custom handlers from executing. This update ensures that `onPress` is properly called after toggling the theme. This allows consumers of `ThemeButton` to perform additional actions, such as storing the theme in local storage.
```
const onPress = () => {
  localStorage.setItem(
    themeLocalStorageKey,
    localStorage.getItem(themeLocalStorageKey) === 'dark' ? 'light' : 'dark'
  );
};
```
```
 <ThemeButton onPress={onPress} />
```
Assuming theme is stored in local storage using some theme initializer:
```
export default function useInitializeTheme() {
  const { setTheme } = useTheme();

  useEffect(() => {
    const storedTheme = localStorage.getItem(themeLocalStorageKey) ?? 'light';
    document.body.setAttribute('data-theme', storedTheme);
    setTheme(storedTheme);
  }, [setTheme]);
}
```