### PR TITLE
Fix `<input>` background bug for `ComboBox` component.

### DIFF
--- a/src/components/ComboBox.module.css
+++ b/src/components/ComboBox.module.css
@@ -11,6 +11,7 @@
   font-size: var(--font-size);
   border: none;
   outline: none;
+	background-color: inherit;
 }
 
 .button {


### PR DESCRIPTION
- Updated `ComboBox.module.css` file with the `.input` class to have a `background-color: inherit` property.

This ensures that the `<input>` background is accordingly updated on light and dark mode.