### PR TITLE
fix: replace items prop with ListItem children in homepage Select and ComboBox

### DIFF
--- a/apps/docs/content/index.mdx
+++ b/apps/docs/content/index.mdx
@@ -134,8 +134,18 @@ title: zen
   <Box padding="5" border borderRadius="lg" marginBottom="6" backgroundColor="surface-base" style={{ breakInside: 'avoid' }}>
     <Column gap="4">
       <Text size="sm" color="muted" weight="medium">Select</Text>
-      <Select label="Country" placeholder="Select country" items={['United States', 'United Kingdom', 'Canada', 'Australia']} />
-      <ComboBox label="Framework" placeholder="Choose one" items={['React', 'Vue', 'Angular', 'Svelte']} />
+      <Select label="Country" placeholder="Select country">
+  <ListItem id="us">United States</ListItem>
+  <ListItem id="uk">United Kingdom</ListItem>
+  <ListItem id="ca">Canada</ListItem>
+  <ListItem id="au">Australia</ListItem>
+</Select>
+      <ComboBox label="Framework" placeholder="Choose one">
+  <ListItem id="react">React</ListItem>
+  <ListItem id="vue">Vue</ListItem>
+  <ListItem id="angular">Angular</ListItem>
+  <ListItem id="svelte">Svelte</ListItem>
+</ComboBox>
     </Column>
   </Box>
 


### PR DESCRIPTION
## What

Fixes #11

The `Select` and `ComboBox` components on the homepage (`index.mdx`) were using an `items` prop that doesn't exist on either component. This caused both dropdowns to render with no options and not respond to clicks.

## Why

The `Select` and `ComboBox` components from `@umami/react-zen` expect `<ListItem>` elements as children — not an `items` array prop. Passing an unsupported prop silently did nothing, leaving the dropdowns empty.

## Fix

Replaced the `items` prop with proper `<ListItem>` children on both components in `apps/docs/content/index.mdx`.

## Before
<img width="468" height="222" alt="image" src="https://github.com/user-attachments/assets/61945e5a-24ea-4c6c-ba28-d337c1545dd1" />

## After
<img width="452" height="334" alt="image" src="https://github.com/user-attachments/assets/5cf1956e-0ce7-481f-9e58-3cbc65a3ae66" />

<img width="441" height="242" alt="image" src="https://github.com/user-attachments/assets/827e5071-db68-4ecd-b692-f2e41b1c83e2" />

## How to test

1. Run `pnpm --filter react-zen-docs dev`
2. Go to `http://localhost:9001`
3. Click the **Country** select → dropdown now shows: United States, United Kingdom, Canada, Australia
4. Click the **Framework** combobox → dropdown now shows: React, Vue, Angular, Svelte

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/react-zen/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783757945&installation_id=134563449&pr_number=12&repository=umami-software%2Freact-zen&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Freact-zen%2Fpull%2F12&signature=99962e560dfcbd411d69d9c677c78074c4b0eb45191546d14891ae3fe7663e1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->